### PR TITLE
fix: package types export

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
       "import": "./dist/index/index.module.js",
       "browser": "./dist/index/index.module.js",
       "require": "./dist/index/index.common.js",
-      "node": "./dist/index/index.common.js"
+      "node": "./dist/index/index.common.js",
+      "types": "./dist/index/index.d.ts"
     },
     "./styles.css": "./dist/index/styles.css"
   },


### PR DESCRIPTION
Trying out the library but getting some type issues when importing and with tsc.

```sh
error TS7016: Could not find a declaration file for module 'solid-confetti-explosion'. '/node_modules/.pnpm/solid-confetti-explosion@1.1.6_solid-js@1.7.8/node_modules/solid-confetti-explosion/dist/index/index.module.js' implicitly has an 'any' type.

There are types at '/node_modules/solid-confetti-explosion/dist/index/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'solid-confetti-explosion' library may need to update its package.json or typings.
```

<img width="792" alt="image" src="https://github.com/davedbase/solid-confetti-explosion/assets/18044529/c8f260cb-b171-40e0-af0b-3076fe33f514">


Visible on [Solid's REPL](https://playground.solidjs.com/anonymous/fab474bf-cbeb-4e69-80a6-a879204355ff) as well